### PR TITLE
ftp.pcre.org is no longer available.

### DIFF
--- a/pkg/pcre/url
+++ b/pkg/pcre/url
@@ -1,1 +1,1 @@
-url = "https://ftp.pcre.org/pub/pcre/pcre-8.45.tar.gz"
+url = "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.gz"


### PR DESCRIPTION
Maybe change to the unofficial mirror suggested by pcre.org?