### PR TITLE
update git to 2.42.0 and consider config.prefix

### DIFF
--- a/pkg/git/gen.lua
+++ b/pkg/git/gen.lua
@@ -31,7 +31,7 @@ build('hooklist', '$outdir/hook-list.h', {
 	'|', '$srcdir/generate-hooklist.sh', '$srcdir/Documentation/githooks.txt'
 })
 
-cc('exec-cmd.c', nil, {cflags=[[$cflags '-DFALLBACK_RUNTIME_PREFIX=""']]})
+cc('exec-cmd.c', nil, {cflags=string.format([[$cflags '-DFALLBACK_RUNTIME_PREFIX="%s"']], config.prefix)})
 cc('common-main.c')
 cc('http.c')
 cc('compat/regex/regex.c', nil, {cflags='$cflags -DGAWK -DNO_MBSUPPORT'})


### PR DESCRIPTION
First commit simply updates git to 2.42.0.

Second commit makes `config.prefix` apply to some of compiled in
paths. It makes git built here usable if its installed to `config.prefix`
rather than `/`.

I omitted the `ETC_*` paths for now but they could also be modified.

Note: `GIT_LOCALE_PATH` isn't actually used anywhere so it was dropped.

See #15.
