### PR TITLE
openbsd: fix url not working

### DIFF
--- a/pkg/openbsd/url
+++ b/pkg/openbsd/url
@@ -1,5 +1,5 @@
 remote-name
-url = "https://fastly.cdn.openbsd.org/pub/OpenBSD/7.3/src.tar.gz"
+url = "https://cdn.openbsd.org/pub/OpenBSD/7.3/src.tar.gz"
 
 remote-name
-url = "https://fastly.cdn.openbsd.org/pub/OpenBSD/7.3/sys.tar.gz"
+url = "https://cdn.openbsd.org/pub/OpenBSD/7.3/sys.tar.gz"


### PR DESCRIPTION
fix the url for openbsd which doesnt work.
see #71 