### PR TITLE
man: don't duplicate section extension

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -494,10 +494,8 @@ function man(srcs, section)
 
 		local base = src:match('[^/]*$')
 		local ext = base:match('%.([^.]*)$')
-		if section then
-			if ext then base = base:sub(1, -(#ext + 2)) end
-			ext = section
-		end
+		if ext then base = base:sub(1, -(#ext + 2)) end
+		if section then ext = section end
 		if config.gzman ~= false then
 			build('gzip', out, src)
 			src = out


### PR DESCRIPTION
I sure this is what was meant. If section isn't specified then ext isn't removed but it is still added in the call to file() resulting in duplication.