### PR TITLE
tree.sh: fix usage message

### DIFF
--- a/scripts/tree.sh
+++ b/scripts/tree.sh
@@ -1,7 +1,7 @@
 set -e
 
 if [ "$#" != 4 ] ; then
-	echo 'usage: commit.sh repo tag index out' >&2
+	echo 'usage: tree.sh repo tag index out' >&2
 	exit 2
 fi
 


### PR DESCRIPTION
Alternatively something like `printf 'usage: %s dir\n' "${0##*/}"` would make the code name independent.